### PR TITLE
Fix types

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ import { isOk, isErr, type AnyResult } from "@travbern/result-util";
  * Use it when you don't want to capture the result value or when you don't care what the result value's type is
  */
 
-function checkResult(result: AnyResult): string {
+function checkResult(result: AnyResult): unknown {
     if (isOk(result)) {
         return result.value; // Ok types have a value field with the result data
     }
@@ -50,7 +50,7 @@ function checkResult(result: AnyResult): string {
  * Result types have an ok field you can also check directly if you hate utility functions and semantic code
  */
 
-function checkResultManually(result: AnyResult): string {
+function checkResultManually(result: AnyResult): unknown {
     if (result.ok) {
         return result.value;
     }

--- a/package.json
+++ b/package.json
@@ -24,8 +24,6 @@
     "homepage": "https://github.com/TravisBernard/result-util#readme",
     "devDependencies": {
         "@biomejs/biome": "2.2.2",
-        "@tsconfig/node-ts": "23.6.1",
-        "@tsconfig/node22": "22.0.2",
         "@types/node": "24.3.0",
         "lefthook": "^1.12.3",
         "tsx": "4.20.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@travbern/result-util",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Some utilities for returning success/fail result objects",
     "type": "module",
     "scripts": {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -20,6 +20,12 @@ suite("Ok", () => {
         assert.strictEqual(result.ok, true);
         assert.strictEqual(result.value.data, 42);
     });
+
+    test("can have an empty argument list", () => {
+        const result = Ok();
+        assert.strictEqual(result.ok, true);
+        assert.strictEqual(result.value, undefined);
+    });
 });
 
 suite("Err", () => {
@@ -27,6 +33,12 @@ suite("Err", () => {
         const result = Err({ message: "Error occurred" });
         assert.strictEqual(result.ok, false);
         assert.strictEqual(result.error.message, "Error occurred");
+    });
+
+    test("can have an empty argument list", () => {
+        const result = Err();
+        assert.strictEqual(result.ok, false);
+        assert.strictEqual(result.error, undefined);
     });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,19 +20,35 @@ export type AnyResult = Result<unknown, unknown>;
 
 /**
  * Creates a successful result.
+ * @returns A ResultOk object with undefined value.
+ */
+export function Ok(): ResultOk<undefined>;
+
+/**
+ * Creates a successful result.
  * @param value - The value to wrap in a successful result.
  * @returns A ResultOk object.
  */
-export function Ok<O>(value: O): ResultOk<O> {
+export function Ok<O>(value: O): ResultOk<O>;
+
+export function Ok<O>(value?: O): ResultOk<O | undefined> {
     return { ok: true, value };
 }
+
+/**
+ * Creates an error result.
+ * @returns A ResultErr object with undefined error.
+ */
+export function Err(): ResultErr<undefined>;
 
 /**
  * Creates an error result.
  * @param error - The error to wrap in an error result.
  * @returns A ResultErr object.
  */
-export function Err<E>(error: E): ResultErr<E> {
+export function Err<E>(error: E): ResultErr<E>;
+
+export function Err<E>(error?: E): ResultErr<E | undefined> {
     return { ok: false, error };
 }
 


### PR DESCRIPTION
`return Ok()` and `return Err()` are valid, you do not need to have a value/error type, but the TS definitions were not allowing for it.