### PR TITLE
Fix ESM/CJS dual build issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@travbern/result-util",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "description": "Some utilities for returning success/fail result objects",
     "type": "module",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -34,9 +34,14 @@
     ],
     "exports": {
         ".": {
-            "import": "./dist/esm/index.js",
-            "require": "./dist/cjs/index.js",
-            "types": "./dist/types/index.d.ts"
+            "import": {
+                "types": "./dist/types/index.d.ts",
+                "default": "./dist/esm/index.js"
+            },
+            "require": {
+                "types": "./dist/types/index.d.ts",
+                "default": "./dist/cjs/index.js"
+            }
         }
     },
     "main": "./dist/cjs/index.js",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "scripts": {
         "build:clean": "rm -rf ./dist",
         "build:esm": "tsc",
-        "build:cjs": "tsc -p tsconfig.cjs.json",
+        "build:cjs": "tsc -p tsconfig.cjs.json && echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json",
         "build": "npm run build:clean && npm run build:esm && npm run build:cjs",
         "test": "tsx --test src/**/*.test.ts",
         "check": "biome check .",

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -2,6 +2,9 @@
     "extends": "./tsconfig.json",
     "compilerOptions": {
         "module": "commonjs",
-        "outDir": "./dist/cjs"
+        "outDir": "./dist/cjs",
+        "declaration": false,
+        "declarationDir": null,
+        "declarationMap": false
     }
 }

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -2,6 +2,7 @@
     "extends": "./tsconfig.json",
     "compilerOptions": {
         "module": "commonjs",
+        "moduleResolution": "node",
         "outDir": "./dist/cjs",
         "declaration": false,
         "declarationDir": null,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
         "target": "ES2021",
         "lib": ["ES2021"],
         "module": "ESNext",
+        "moduleResolution": "bundler",
 
         "rootDir": "./src",
         "outDir": "./dist/esm",


### PR DESCRIPTION
## Summary

- Fix CJS `require()` failing with `ERR_REQUIRE_ESM` by emitting a `dist/cjs/package.json` with `{"type":"commonjs"}` (closes #7)
- Stop CJS build from generating duplicate `.d.ts` files
- Nest `types` conditions under `import`/`require` exports for proper TypeScript 4.7+ resolution
- Set `moduleResolution: "bundler"` so TypeScript understands the `exports` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)